### PR TITLE
v2-result-filename-fix: Fixing the filename in scan result

### DIFF
--- a/pkg/server/grpc.go
+++ b/pkg/server/grpc.go
@@ -98,6 +98,7 @@ func (s *gRPCServer) FindMalwareInfo(c context.Context, r *pb.MalwareRequest) (*
 			if err != nil {
 				return
 			}
+			trim = true
 		} else {
 			err = fmt.Errorf("Invalid request")
 			return


### PR DESCRIPTION
Changing the filenames in the results 
**From:**
/fenced/mnt/host/var/lib/docker/overlay2/1df37fa488f52cda2872c14c6b0b66b7c9963f6f40774a8b325d7f0b678d7663/merged/usr/include/glib-2.0/glib/gnode.h

**To:**
/var/lib/docker/overlay2/1df37fa488f52cda2872c14c6b0b66b7c9963f6f40774a8b325d7f0b678d7663/merged/usr/include/glib-2.0/glib/gnode.h