### PR TITLE
fix links to Roadmap and ThreatMapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,25 +5,24 @@
 [![GitHub issues](https://img.shields.io/github/issues/deepfence/YaraHunter)](https://github.com/deepfence/YaraHunter/issues)
 [![Slack](https://img.shields.io/badge/slack-@deepfence-blue.svg?logo=slack)](https://join.slack.com/t/deepfence-community/shared_invite/zt-podmzle9-5X~qYx8wMaLt9bGWwkSdgQ)
 
-
 # YaraHunter
 
 Deepfence YaraHunter scans container images, running Docker containers, and filesystems to find indicators of malware. It uses a [YARA ruleset](https://github.com/deepfence/yara-rules) to identify resources that match known malware signatures, and may indicate that the container or filesystem has been compromised.
 
 YaraHunter can be used in the following ways:
 
- * **At build-and-test**: scan build artifacts in the CI/CD pipeline, reporting on possible indicators of malware
- * **At rest**: scan local container images, for example, before they are deployed, to verify they do not contain malware
- * **At runtime**: scan running docker containers, for example, if you observe unusual network traffic or CPU activity
- * **Against filesystems**: at any time, YaraHunter can scan a local filesystems for indicators of compromise
+- **At build-and-test**: scan build artifacts in the CI/CD pipeline, reporting on possible indicators of malware
+- **At rest**: scan local container images, for example, before they are deployed, to verify they do not contain malware
+- **At runtime**: scan running docker containers, for example, if you observe unusual network traffic or CPU activity
+- **Against filesystems**: at any time, YaraHunter can scan a local filesystems for indicators of compromise
 
 Key capabilities:
 
- * Scan running and at-rest containers; scan filesystems; scan during CI/CD build operations
- * Run anywhere: highly-portable, docker container form factor
- * Designed for automation: easy-to-deploy, easy-to-parse JSON output
+- Scan running and at-rest containers; scan filesystems; scan during CI/CD build operations
+- Run anywhere: highly-portable, docker container form factor
+- Designed for automation: easy-to-deploy, easy-to-parse JSON output
 
-YaraHunter is a work-in-progress (check the [Roadmap](https://github.com/orgs/deepfence/projects/3) and [issues list](issues)), and will be integrated into the [ThreatMapper](/deepfence/ThreatMapper) threat discovery platform.  We welcome any contributions to help to improve this tool.
+YaraHunter is a work-in-progress (check the [Roadmap](https://github.com/deepfence/YaraHunter/projects) and [issues list](issues)), and will be integrated into the [ThreatMapper](https://github.com/deepfence/ThreatMapper) threat discovery platform. We welcome any contributions to help to improve this tool.
 
 ## Quick Start
 
@@ -33,7 +32,7 @@ For full instructions, refer to the [YaraHunter Documentation](https://docs.deep
 
 ## Example: Finding Indicators of Compromise in a container image
 
-Images may be compromised with the installation of a cryptominer such as XMRig.  In the following example, we'll scan a legitimiate cryptominer image that contains the same xmrig software that is often installed through an exploit:
+Images may be compromised with the installation of a cryptominer such as XMRig. In the following example, we'll scan a legitimiate cryptominer image that contains the same xmrig software that is often installed through an exploit:
 
 Pull the official **yarahunter** image:
 
@@ -53,7 +52,7 @@ docker run -it --rm --name=deepfence-yarahunter \
      --json-filename=xmrig-scan.json
 ```
 
-This returns, among other things, clear indication of the presence of XMRig.  Note that we store the output (`/tmp/xmrig-scan.json`) for quick and easy manipulation:
+This returns, among other things, clear indication of the presence of XMRig. Note that we store the output (`/tmp/xmrig-scan.json`) for quick and easy manipulation:
 
 ```
 # Extract the IOC array values.  From these, extract the values of the 'Matched Rule Name' key
@@ -66,15 +65,15 @@ This returns a list of the IOCs identified in the container we scanned.
 
 Thank you for using YaraHunter.
 
- * [<img src="https://img.shields.io/badge/documentation-read-green">](https://docs.deepfence.io/docs/yarahunter/) Start with the documentation
- * [<img src="https://img.shields.io/badge/slack-@deepfence-blue.svg?logo=slack">](https://join.slack.com/t/deepfence-community/shared_invite/zt-podmzle9-5X~qYx8wMaLt9bGWwkSdgQ) Got a question, need some help?  Find the Deepfence team on Slack
- * [![GitHub issues](https://img.shields.io/github/issues/deepfence/YaraHunter)](https://github.com/deepfence/YaraHunter/issues) Got a feature request or found a bug? Raise an issue
- * [productsecurity *at* deepfence *dot* io](SECURITY.md): Found a security issue? Share it in confidence
- * Find out more at [deepfence.io](https://deepfence.io/)
+- [<img src="https://img.shields.io/badge/documentation-read-green">](https://docs.deepfence.io/docs/yarahunter/) Start with the documentation
+- [<img src="https://img.shields.io/badge/slack-@deepfence-blue.svg?logo=slack">](https://join.slack.com/t/deepfence-community/shared_invite/zt-podmzle9-5X~qYx8wMaLt9bGWwkSdgQ) Got a question, need some help? Find the Deepfence team on Slack
+- [![GitHub issues](https://img.shields.io/github/issues/deepfence/YaraHunter)](https://github.com/deepfence/YaraHunter/issues) Got a feature request or found a bug? Raise an issue
+- [productsecurity _at_ deepfence _dot_ io](SECURITY.md): Found a security issue? Share it in confidence
+- Find out more at [deepfence.io](https://deepfence.io/)
 
 ## Security and Support
 
-For any security-related issues in the YaraHunter project, contact [productsecurity *at* deepfence *dot* io](SECURITY.md).
+For any security-related issues in the YaraHunter project, contact [productsecurity _at_ deepfence _dot_ io](SECURITY.md).
 
 Please file GitHub issues as needed, and join the Deepfence Community [Slack channel](https://join.slack.com/t/deepfence-community/shared_invite/zt-podmzle9-5X~qYx8wMaLt9bGWwkSdgQ).
 


### PR DESCRIPTION
I've proposed replacements for the following 2 broken links in the README.md file:
- Roadmap
- ThreatMapper