### PR TITLE
fix file closing issue in updater

### DIFF
--- a/main.go
+++ b/main.go
@@ -68,7 +68,7 @@ func main() {
 		wg.Add(1)
 		err := runner.StartYaraHunterUpdater(*opts.ConfigPath, *opts.RulesPath, *opts.RulesListingURL)
 		if err != nil {
-			log.Panicf("main: failed to serve: %v", err)
+			log.Panicf("main: failed to start updater: %v", err)
 		}
 		go runner.ScheduleYaraHunterUpdater(opts, &wg)
 	}

--- a/pkg/runner/updater.go
+++ b/pkg/runner/updater.go
@@ -61,17 +61,17 @@ func StartYaraHunterUpdater(rulesPath, configPath, rulesListingURL string) error
 			yaraRuleUpdater.currentFileChecksum = yaraRuleListingJSON.Available.V3[0].Checksum
 			file, err := json.MarshalIndent(yaraRuleUpdater, "", " ")
 			if err != nil {
-				log.Errorf("main: failed to serve: %v", err)
+				log.Errorf("main: failed to marshal: %v", err)
 				return err
 			}
 			err = os.WriteFile(path.Join(rulesPath, "metaListingData.json"), file, 0644)
 			if err != nil {
-				log.Errorf("main: failed to serve: %v", err)
+				log.Errorf("main: failed to write to metaListingData.json: %v", err)
 				return err
 			}
 			fileName, err := utils.DownloadFile(yaraRuleListingJSON.Available.V3[0].URL, configPath)
 			if err != nil {
-				log.Errorf("main: failed to serve: %v", err)
+				log.Errorf("main: failed to download file: %v", err)
 				return err
 			}
 
@@ -80,7 +80,7 @@ func StartYaraHunterUpdater(rulesPath, configPath, rulesListingURL string) error
 
 				readFile, readErr := os.OpenFile(filepath.Join(configPath, fileName), os.O_CREATE|os.O_RDWR, 0755)
 				if readErr != nil {
-					log.Errorf("main: failed to serve: %v", readErr)
+					log.Errorf("main: failed to open rules tar file : %v", readErr)
 					return readErr
 				}
 
@@ -88,7 +88,7 @@ func StartYaraHunterUpdater(rulesPath, configPath, rulesListingURL string) error
 
 				newFile, err := utils.CreateFile(configPath, "malware.yar")
 				if err != nil {
-					log.Errorf("main: failed to create: %v", err)
+					log.Errorf("main: failed to create malware.yar: %v", err)
 					return err
 				}
 
@@ -96,7 +96,7 @@ func StartYaraHunterUpdater(rulesPath, configPath, rulesListingURL string) error
 
 				err = utils.Untar(newFile, readFile)
 				if err != nil {
-					log.Errorf("main: failed to serve: %v", err)
+					log.Errorf("main: failed to untar: %v", err)
 					return err
 				}
 			}

--- a/pkg/scan/process_image.go
+++ b/pkg/scan/process_image.go
@@ -163,18 +163,16 @@ func calculateSeverity(inputString []string, severity string, severityScore floa
 func ScanFilePath(s *Scanner, path string, iocs *[]output.IOCFound, layer string) (err error) {
 	f, err := os.Open(path)
 	if err != nil {
-		logrus.Errorf("Error: %v", err)
 		return err
 	}
 	defer f.Close()
 	if _, err := f.Seek(0, io.SeekStart); err != nil {
-		logrus.Errorf("Could not seek to start of file %s: %v", path, err)
 		return err
 	}
-	if e := ScanFile(s, f, iocs, layer); err == nil && e != nil {
-		err = e
+	if err = ScanFile(s, f, iocs, layer); err != nil {
+		return err
 	}
-	return
+	return nil
 }
 
 func isSharedLibrary(filePath string) bool {
@@ -430,7 +428,8 @@ func (s *Scanner) ScanIOCInDir(layer string, baseDir string, fullDir string, mat
 		}
 		tmpIOCs := []output.IOCFound{}
 		if err = ScanFilePath(s, path, &tmpIOCs, layer); err != nil {
-			logrus.Errorf("Scan file failed: %v", err)
+			logrus.Warnf("Scan file failed: %v", err)
+			return nil
 		}
 
 		*iocs = append(*iocs, tmpIOCs...)
@@ -519,7 +518,7 @@ func (s *Scanner) ScanIOCInDirStream(layer string, baseDir string, fullDir strin
 			}
 			tmpIOCs := []output.IOCFound{}
 			if err = ScanFilePath(s, path, &tmpIOCs, layer); err != nil {
-				logrus.Errorf("Scan file failed: %v", err)
+				logrus.Warnf("Scan file failed: %v", err)
 			}
 
 			for i := range tmpIOCs {

--- a/utils/utils.go
+++ b/utils/utils.go
@@ -109,7 +109,6 @@ func Untar(d *os.File, r io.Reader) error {
 			if _, err := io.Copy(d, tr); err != nil {
 				return err
 			}
-			d.Close()
 		}
 	}
 }


### PR DESCRIPTION
- fixes premature file closing while updating yara rules
-  better error messages
- use warn logs instead of error if filewalking errored out
- minor refactor