### PR TITLE
optimise yarahunter

### DIFF
--- a/pkg/scan/process_image.go
+++ b/pkg/scan/process_image.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"path"
 	"path/filepath"
+	"slices"
 	"strings"
 	"syscall"
 
@@ -279,18 +280,12 @@ func ScanFile(s *Scanner, f *os.File, iocs *[]output.IOCFound, layer string) err
 	var iocsFound []output.IOCFound
 	totalMatchesStringData := make([]string, 0)
 	for _, m := range matches {
-		matchesStringData := make(map[string]struct{})
 		for _, str := range m.Strings {
-			if _, exists := matchesStringData[string(str.Data)]; !exists {
-				matchesStringData[string(str.Data)] = struct{}{}
-				totalMatchesStringData = append(totalMatchesStringData, string(str.Data))
-			}
+			totalMatchesStringData = append(totalMatchesStringData, string(str.Data))
 		}
-		// Convert map keys to slice since the rest of your code expects a slice
-		matchesStringDataSlice := make([]string, 0, len(matchesStringData))
-		for key := range matchesStringData {
-			matchesStringDataSlice = append(matchesStringDataSlice, key)
-		}
+
+		slices.Sort(totalMatchesStringData)
+		matchesStringDataSlice := slices.Compact(totalMatchesStringData)
 
 		matchesMetaData := make([]string, len(m.Metas))
 		for _, strMeta := range m.Metas {

--- a/pkg/scan/process_image.go
+++ b/pkg/scan/process_image.go
@@ -279,13 +279,19 @@ func ScanFile(s *Scanner, f *os.File, iocs *[]output.IOCFound, layer string) err
 	var iocsFound []output.IOCFound
 	totalMatchesStringData := make([]string, 0)
 	for _, m := range matches {
-		matchesStringData := make([]string, len(m.Strings))
+		matchesStringData := make(map[string]struct{})
 		for _, str := range m.Strings {
-			if !strings.Contains(strings.Join(matchesStringData, " "), string(str.Data)) {
-				matchesStringData = append(matchesStringData, string(str.Data))
+			if _, exists := matchesStringData[string(str.Data)]; !exists {
+				matchesStringData[string(str.Data)] = struct{}{}
 				totalMatchesStringData = append(totalMatchesStringData, string(str.Data))
 			}
 		}
+		// Convert map keys to slice since the rest of your code expects a slice
+		matchesStringDataSlice := make([]string, 0, len(matchesStringData))
+		for key := range matchesStringData {
+			matchesStringDataSlice = append(matchesStringDataSlice, key)
+		}
+
 		matchesMetaData := make([]string, len(m.Metas))
 		for _, strMeta := range m.Metas {
 			matchesMetaData = append(matchesMetaData, fmt.Sprintf("%v : %v \n", strMeta.Identifier, strMeta.Value))
@@ -294,7 +300,7 @@ func ScanFile(s *Scanner, f *os.File, iocs *[]output.IOCFound, layer string) err
 		iocsFound = append(iocsFound, output.IOCFound{
 			RuleName:         m.Rule,
 			CategoryName:     m.Tags,
-			StringsToMatch:   matchesStringData,
+			StringsToMatch:   matchesStringDataSlice,
 			Meta:             matchesMetaData,
 			CompleteFilename: fileName,
 		})

--- a/pkg/scan/process_image.go
+++ b/pkg/scan/process_image.go
@@ -15,6 +15,7 @@ import (
 	"slices"
 	"strings"
 	"syscall"
+	"unsafe"
 
 	"fmt"
 
@@ -211,6 +212,10 @@ func isExecutable(path string) bool {
 	return fileMimetypeCheck(path, execMimeTypes)
 }
 
+func BytesToString(b []byte) (s string) {
+	return unsafe.String(unsafe.SliceData(b), len(b))
+}
+
 func ScanFile(s *Scanner, f *os.File, iocs *[]output.IOCFound, layer string) error {
 	logrus.Debugf("Scanning file %s", f.Name())
 	var (
@@ -281,7 +286,7 @@ func ScanFile(s *Scanner, f *os.File, iocs *[]output.IOCFound, layer string) err
 	totalMatchesStringData := make([]string, 0)
 	for _, m := range matches {
 		for _, str := range m.Strings {
-			totalMatchesStringData = append(totalMatchesStringData, string(str.Data))
+			totalMatchesStringData = append(totalMatchesStringData, BytesToString(str.Data))
 		}
 
 		slices.Sort(totalMatchesStringData)

--- a/pkg/scan/process_image.go
+++ b/pkg/scan/process_image.go
@@ -262,7 +262,7 @@ func ScanFile(s *Scanner, f *os.File, iocs *[]output.IOCFound, layer string) err
 	}
 	err = yrScanner.ScanFileDescriptor(f.Fd())
 	if err != nil {
-		fmt.Println("Scan File Descriptor error, trying alternative", err)
+		logrus.Errorf("yara: %s: Error scanning file, error=%s, trying alternative", fileName, err.Error())
 		var buf []byte
 		if buf, err = io.ReadAll(f); err != nil {
 			logrus.Errorf("yara: %s: Error reading file, error=%s",
@@ -271,7 +271,7 @@ func ScanFile(s *Scanner, f *os.File, iocs *[]output.IOCFound, layer string) err
 		}
 		err = yrScanner.ScanMem(buf)
 		if err != nil {
-			fmt.Println("Scan File Mmory Error", err)
+			logrus.Errorf("yara: %s: Error scanning file, error=%s", fileName, err.Error())
 			return filepath.SkipDir
 		}
 


### PR DESCRIPTION
- Using string.Join on million of record is really slow. Using Map here were reads and writes are in o(1)
- using fmt writes the error log to stdout, that then goes to json. which we don't want.

// todo
- size of output(result) json can grow depending on stringsMatch, need fix for that
- size of map will increase the in-mem usage, need to fix this