### PR TITLE
Update config.yaml

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3,4 +3,4 @@
 exclude_extensions: [ ".log", ".jpg", ".jpeg", ".png", ".gif", ".bmp", ".tiff", ".tif", ".psd", ".xcf", ".zip", ".tar.gz",".gz",".so", ".0", ".1", ".2", ".3",".4",".5",".6",".7",".8",".9", ".ttf", ".lock", ".yar", ".log", ".chk", ".sdb", ".jdb", ".pat", ".jrs", ".dit", ".pol", ".mdb", ".dns", ".admx", ".adml", ".adm", ".edb", ".db", ".evtx"]
 exclude_paths: ["/var/lib/docker", "/var/lib/containerd", "/dev", "/proc", "/usr/lib", "/sys", "/boot", "/run"]
 max_file_size: 1073741824
-skip_non_executable: true
+skip_non_executable: false


### PR DESCRIPTION
in case where target file is inside tar, checking executable fails. turning this off till we find way around