### PR TITLE
Scan non executable files, fix severity

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,6 +1,6 @@
 # Iac Scanner Configuration File
 
-exclude_extensions: [ ".log", ".jpg", ".jpeg", ".png", ".gif", ".bmp", ".tiff", ".tif", ".psd", ".xcf", ".zip", ".tar.gz",".gz",".so", ".0", ".1", ".2", ".3",".4",".5",".6",".7",".8",".9", ".ttf", ".lock", ".yar", ".log", ".chk", ".sdb", ".jdb", ".pat", ".jrs", ".dit", ".pol", ".mdb", ".dns", ".admx", ".adml", ".adm", ".edb", ".db", ".evtx"]
+exclude_extensions: [ ".log", ".jpg", ".jpeg", ".png", ".gif", ".bmp", ".tiff", ".tif", ".psd", ".xcf",".so", ".0", ".1", ".2", ".3",".4",".5",".6",".7",".8",".9", ".ttf", ".lock", ".yar", ".log", ".chk", ".sdb", ".jdb", ".pat", ".jrs", ".dit", ".pol", ".mdb", ".dns", ".admx", ".adml", ".adm", ".edb", ".db", ".evtx"]
 exclude_paths: ["/var/lib/docker", "/var/lib/containerd", "/dev", "/proc", "/usr/lib", "/sys", "/boot", "/run"]
 max_file_size: 1073741824
-skip_non_executable: true
+skip_non_executable: false

--- a/main.go
+++ b/main.go
@@ -81,6 +81,7 @@ func main() {
 
 	level, err := log.ParseLevel(*opts.LogLevel)
 	if err != nil {
+		log.Warnf("Invalid log level '%s', defaulting to 'info': %v", *opts.LogLevel, err)
 		level = log.InfoLevel
 	}
 	log.SetLevel(level)

--- a/main.go
+++ b/main.go
@@ -61,7 +61,6 @@ var (
 
 func main() {
 	log.SetOutput(os.Stderr)
-	log.SetLevel(log.InfoLevel)
 	log.SetReportCaller(true)
 	log.SetFormatter(&log.TextFormatter{
 		DisableColors: false,
@@ -72,8 +71,6 @@ func main() {
 		},
 	})
 
-	log.Infof("version: %s", version)
-
 	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt)
 	defer cancel()
 
@@ -81,6 +78,15 @@ func main() {
 	if err != nil {
 		log.Fatalf("main: failed to parse options: %v", err)
 	}
+
+	level, err := log.ParseLevel(*opts.LogLevel)
+	if err != nil {
+		level = log.InfoLevel
+	}
+	log.SetLevel(level)
+
+	log.Infof("version: %s", version)
+
 	config, err := cfg.ParseConfig(*opts.ConfigPath)
 	if err != nil {
 		log.Fatalf("main: failed to parse config: %v", err)

--- a/pkg/config/options.go
+++ b/pkg/config/options.go
@@ -47,10 +47,12 @@ type Options struct {
 	Product              *string
 	Version              *string
 	License              *string
+	LogLevel             *string
 }
 
 func ParseOptions() (*Options, error) {
 	options := &Options{
+		LogLevel:             flag.String("log-level", "info", "Log levels are one of error, warn, info, debug. Only levels higher than the log-level are displayed"),
 		RulesPath:            flag.String("rules-path", "/home/deepfence/usr", "All .yar and .yara files in the given directory will be compiled"),
 		FailOnCompileWarning: flag.Bool("fail-on-rule-compile-warn", false, "Fail if yara rule compilation has warnings"),
 		Threads:              flag.Int("threads", 0, "Number of concurrent threads (default number of logical CPUs)"),


### PR DESCRIPTION
Scanning container image quay.io/petr_ruzicka/malware-cryptominer-container skips every file because they are not executable ones